### PR TITLE
Add `application/ogg` support

### DIFF
--- a/player/internal/streamer.go
+++ b/player/internal/streamer.go
@@ -28,6 +28,7 @@ const (
 	contentTypePls  = "audio/x-scpls"
 	contentTypeMpeg = "audio/mpeg"
 	contentTypeOgg  = "audio/ogg"
+	contentTypeOgg2 = "application/ogg"
 	contentTypeAac  = "audio/aac"
 	contentTypeAacp = "audio/aacp"
 )
@@ -378,7 +379,7 @@ func getDecoder(contentType string) (
 	switch contentType {
 	case contentTypeMpeg:
 		return mp3.Decode, nil
-	case contentTypeOgg:
+	case contentTypeOgg,contentTypeOgg2:
 		return vorbis.Decode, nil
 	case contentTypeAac, contentTypeAacp:
 		return nil, errAACNotAvailable


### PR DESCRIPTION
Some stations send the content type header as `application/ogg` instead of the expected `audio/ogg`. This commit just adds that to the internal player.

- " Nightwave Plaza", https://radio.plaza.one/ogg
- "Nightwave Plaza OPUS 96", https://radio.plaza.one/opus

I've tested it locally that these stations work:
<img width="981" height="225" alt="image" src="https://github.com/user-attachments/assets/d3093f0c-69ff-4e23-96a0-aaf9849266bb" />
